### PR TITLE
Updated installation commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ With ABBA Python, you can control ABBA API from python, and get some additional 
 2. Create a conda environment with Python 3.10, OpenJDK 8 and maven and activate it
 3. Install abba_python
 ```
-conda create -c conda-forge -n abba-env python=3.10 openjdk=8 maven
+conda create -c conda-forge -n abba-env python=3.10 openjdk=8 pip maven
 
 conda activate abba-env
 


### PR DESCRIPTION
In the current version of README, it creates a bare conda environment, without `python` nor `pip`. So the following `pip install abba_python` command uses the `pip` from conda `base` environment and installs abba_python in it, which might lead to conflicts in the user's conda `base`.

Notes :
- It should fix [issue #10](https://github.com/BIOP/abba_python/issues/10). [doumazane](https://github.com/doumazane) said they were preparing a PR involving a conda .yaml environment file (which might be the way to go), but in the meantime, since the current instructions can lead to problems in users' conda instllation, here's a quick fix.
- This is my first PR so I basically have no idea what I'm doing, but I guess (hope) Github is smart enough to not let me break anything.
- Those are the commands I used to install latest abba_python which worked like a charm (so yes, python 3.10 works :) )