### PR TITLE
Fix "no module named 'abba_private'"

### DIFF
--- a/src/abba_python/abba.py
+++ b/src/abba_python/abba.py
@@ -178,7 +178,7 @@ class Abba:
             else:
                 bg_atlas = BrainGlobeAtlas(atlas_name)
                 # initialized
-                from abba_private import abba_atlas
+                from abba_python.abba_private import abba_atlas
                 atlas = abba_atlas.AbbaAtlas(bg_atlas, ij)
                 atlas.initialize(None, None)
                 Abba.opened_atlases[atlas_name] = atlas


### PR DESCRIPTION
Fix https://github.com/BIOP/abba_python/issues/14#issuecomment-2031940552

Still not sure why it didn't work before but at least we'll have a working version for now.