### PR TITLE
Tame down platform error message

### DIFF
--- a/src/abba_python/abba.py
+++ b/src/abba_python/abba.py
@@ -116,7 +116,7 @@ def start_imagej(headless: bool = False,
             # directory already exists ?
             pass
     else:
-        print('ERROR! ' + platform.system() + ' OS not tested.')
+        print('[WARNING] Support for third-party brain atlases through BrainGlobe is primarily tested on Windows. If you encounter any OS-specific issues on ' + platform.system() + ', please report them to the developers: https://github.com/BIOP/abba_python/issues')
     pass
 
     if not headless:


### PR DESCRIPTION
Hi!
With this PR i intend to improve the warning message that `abba_python` prints when ABBA is run outside of Windows.
I have already had multiple reports of users scared by the error message `ERROR! Linux OS not tested.`
To my knowledge and experience, Linux platform is absolutely fine and it's not an error in itself to use it for ABBA. However I understand that Linux platform is not be your first focus, so I think it's good to keep it as a explanatory warning